### PR TITLE
[RFC] Address HTML nits

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 
   <head>
     <script src="index.js"></script>
+    <style>
+      * {
+          padding: 0;
+          margin: 0;
+      }
+    </style>
   </head>
-  <style>
-    * {
-        padding: 0;
-        margin: 0;
-    }
-  </style>
 
-  <body onload='run()' style='background:black'>
-    <canvas id='scene' width='500px' height='500px' style='background:black; display: block; margin: 0 auto'></canvas>
+  <body onload="run()" style="background:black">
+    <canvas id="scene" width="500px" height="500px" style="background:black; display: block; margin: 0 auto"></canvas>
     <a href="https://github.com/anvaka/atree"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
   </body>
 


### PR DESCRIPTION
This moves the style block to the head, and makes all HTML attributes
use double quotes instead of single quotes.

Fixes #11